### PR TITLE
Update setup.py template

### DIFF
--- a/python_git_package/templates/setup.py
+++ b/python_git_package/templates/setup.py
@@ -6,14 +6,15 @@ setuppath = os.path.dirname(os.path.abspath(__file__))
 
 # retrieve the version
 try:
-    versionfile = os.path.join(setuppath,'{packagename_file}','__version__.py')
-    f = open( versionfile, 'r')
+    versionfile = os.path.join(setuppath, '{packagename_file}', '__version__.py')
+    f = open(versionfile, 'r')
     content = f.readline()
     splitcontent = content.split('\'')
     version = splitcontent[1]
     f.close()
-except:
-    raise Exception('Could not determine the version from {packagename_file}/__version__.py')
+except Exception:
+    raise Exception(
+        'Could not determine the version from {packagename_file}/__version__.py')
 
 
 # run the setup command


### PR DESCRIPTION
Fix using PEP-8
`setup.py:9:41,57: E231 missing whitespace after ','`
`setup.py:10:14: E201 whitespace after '('`
`setup.py:15:1: E722 do not use bare except'`
`setup.py:16:80: E501 line too long (88 > 79 characters)`
